### PR TITLE
Fix api-key dto array type

### DIFF
--- a/src/api-key/dto/create-api-key.dto.ts
+++ b/src/api-key/dto/create-api-key.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateApiKeyDto {
   @IsString()
@@ -7,5 +7,7 @@ export class CreateApiKeyDto {
 }
 export class CreateArrApiKeyDto {
   @IsNotEmpty()
-  keys: [string];
+  @IsArray()
+  @IsString({ each: true })
+  keys: string[];
 }


### PR DESCRIPTION
## Summary
- update `CreateArrApiKeyDto` validation to handle array of keys

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a67d964788325a534e72744a0de55