### PR TITLE
Add unit tests for auth utils

### DIFF
--- a/src/auth/utils/func.spec.ts
+++ b/src/auth/utils/func.spec.ts
@@ -1,0 +1,21 @@
+import { generatePassword, extractOrderId } from './func';
+
+describe('generatePassword', () => {
+  it('returns a string of the requested length', () => {
+    const length = 12;
+    const password = generatePassword(length);
+    expect(typeof password).toBe('string');
+    expect(password).toHaveLength(length);
+  });
+});
+
+describe('extractOrderId', () => {
+  it('extracts the id from a valid order code', () => {
+    const code = 'ORDER-98765_PAYPAL';
+    expect(extractOrderId(code)).toBe('98765');
+  });
+
+  it('returns null for an invalid order code', () => {
+    expect(extractOrderId('INVALIDCODE')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for password generation and order id extraction

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a686f8d148325b83ced0c7e5a290d